### PR TITLE
Added healthcheck endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,7 @@ GIN_MODE=release # Never run debug in production!
 
 # Ticket Server Settings
 TICKET_API_URL="https://tickets.example.com/api/tickets.json"
+TICKET_HEALTH_URL="https://tickets.example.com"
 TICKET_API_KEY="abc123"
 TICKET_SHOULD_ALERT=true
 TICKET_SHOULD_AUTORESPOND=true

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ variables.
 | `TRUSTED_PROXIES`           | :x:                | Proxy servers to trust when reading client IP headers. Provide addresses in a comma separated list.Defaults to `*`. | `192.0.2.1,192.0.2.2,2001:db8::1,2001:db8::2`  |
 | `GIN_MODE`                  | :x:                | Mode to run Gin in. Only set to `debug` for development. Defaults to `release`.                                     | `release`                                      |
 | `TICKET_API_URL`            | :heavy_check_mark: | URL of endpoint to call when submitting a ticket.                                                                   | `https://tickets.example.com/api/tickets.json` |
+| `TICKET_HEALTH_URL`         | :heavy_check_mark: | URL of endpoint to call for health checks on the ticketing system.                                                  | `https://tickets.example.com`                  |
 | `TICKET_API_KEY`            | :heavy_check_mark: | API key to pass in `X-API-Key` header to server.                                                                    |                                                |
 | `TICKET_SHOULD_ALERT`       | :x:                | Should an alert be sent by ticketing system to agents? Defaults to `true`.                                          |                                                |
 | `TICKET_SHOULD_AUTORESPOND` | :x:                | Should an autoresponse email be sent to the user? Defaults to `true`.                                               |                                                |

--- a/controller/messaging.controller.go
+++ b/controller/messaging.controller.go
@@ -17,6 +17,7 @@ import (
 
 type MessagingController interface {
 	Contact(ctx *gin.Context)
+    HealthCheck(ctx *gin.Context)
 }
 
 type messagingController struct {
@@ -45,6 +46,15 @@ func (controller messagingController) SendMessage(ctx *gin.Context) {
 	}
 }
 
+func (controller messagingController) HealthCheck(ctx *gin.Context) {
+    if err := controller.service.HealthCheck(); err != nil {
+        ctx.String(http.StatusServiceUnavailable, "unhealthy")
+        ctx.Abort()
+        return
+    }
+    ctx.String(http.StatusOK, "healthy")
+}
+
 func NewMessagingController(engine *gin.Engine, messagingService service.MessagingService) {
     controller := &messagingController{
         service: messagingService,
@@ -52,5 +62,6 @@ func NewMessagingController(engine *gin.Engine, messagingService service.Messagi
     api := engine.Group("messaging")
     {
         api.POST("contact", controller.SendMessage)
+        api.GET("health", controller.HealthCheck)
     }
 }

--- a/main.go
+++ b/main.go
@@ -34,6 +34,7 @@ func init() {
 
     // Ticket server settings
     util.TicketAPIURL = util.Mustgetenv(util.TicketAPIURLEnv)
+    util.TicketHealthURL = util.Mustgetenv(util.TicketHealthURLEnv)
     util.TicketAPIKey = util.Mustgetenv(util.TicketAPIKeyEnv)
     util.TicketShouldAlert = util.BGetenv(util.TicketShouldAlertEnv, util.DefaultTicketShouldAlert)
     util.TicketShouldAutorespond = util.BGetenv(util.TicketShouldAutorespondEnv, util.DefaultTicketShouldAutorespond)

--- a/service/messaging.service.go
+++ b/service/messaging.service.go
@@ -17,6 +17,7 @@ import (
 
 type MessagingService interface {
     SendMessage(message *model.Message) error
+    HealthCheck() error
 }
 
 type messagingService struct {
@@ -58,6 +59,21 @@ func (service *messagingService) SendMessage(message *model.Message) error {
             return fmt.Errorf("got bad response from API: %d %s", resp.StatusCode, string(body))
         }
         return nil
+}
+
+func (service *messagingService) HealthCheck() error {
+    resp, err := http.Get(util.TicketHealthURL)
+    if err != nil {
+        return err
+    }
+
+    defer resp.Body.Close()
+
+    if resp.StatusCode != http.StatusOK {
+        body, _ := io.ReadAll(resp.Body)
+        return fmt.Errorf("got bad response from health check: %d %s", resp.StatusCode, string(body))
+    }
+    return nil
 }
 
 func NewMessagingService() MessagingService {

--- a/util/config.go
+++ b/util/config.go
@@ -11,6 +11,8 @@ var (
 	TrustedProxies []string
 	// URL for ticketing system API
 	TicketAPIURL string
+    // URL to use for ticketing system health checks
+    TicketHealthURL string
 	// API key for ticketing system
 	TicketAPIKey string
 	// Should the ticketing system alert on a new message?
@@ -26,6 +28,7 @@ const (
 	BindAddrEnv                = "BIND_ADDRESS"
 	TrustedProxiesEnv          = "TRUSTED_PROXIES"
 	TicketAPIURLEnv            = "TICKET_API_URL"
+    TicketHealthURLEnv         = "TICKET_HEALTH_URL"
 	TicketAPIKeyEnv            = "TICKET_API_KEY"
 	TicketShouldAlertEnv       = "TICKET_SHOULD_ALERT"
 	TicketShouldAutorespondEnv = "TICKET_SHOULD_AUTORESPOND"


### PR DESCRIPTION
Added a healthcheck endpoint to the service. This allows a user to determine if the API is usable or not. It checks the backend ticketing service is accessible.